### PR TITLE
update gae proxy list

### DIFF
--- a/roles/haproxy/files/gae-proxy-routes.lst
+++ b/roles/haproxy/files/gae-proxy-routes.lst
@@ -3,6 +3,7 @@
 
 /account
 /admin
+/android-career-summit
 /api
 /callbacks/sendgrid
 /career-paths/data-analyst
@@ -32,13 +33,22 @@
 /lti
 /lti/
 /me
+/mobile
 /my_courses
+/nanodegree/50-back
+/nanodegree/android-expectation-quiz
+/nanodegree/data-analyst-expectation-quiz
+/open-ed
+/opened
 /oauth2callback
 /openid
+/programming-languages/python
+/programming-languages/swift
 /proxy/requisitions
 /quiz
 /quiz_instructions
 /quiz/instructions
+/success
 /teacher/
 /teams
 /templates

--- a/roles/haproxy/files/gae-proxy-routes.lst
+++ b/roles/haproxy/files/gae-proxy-routes.lst
@@ -2,6 +2,7 @@
 # NOTE: We use `path_beg` to match, so anything under the path will route.
 
 /account
+/admin
 /api
 /callbacks/sendgrid
 /career-paths/data-analyst

--- a/roles/haproxy/files/gae-proxy-routes.lst
+++ b/roles/haproxy/files/gae-proxy-routes.lst
@@ -2,7 +2,6 @@
 # NOTE: We use `path_beg` to match, so anything under the path will route.
 
 /account
-/admin
 /api
 /callbacks/sendgrid
 /career-paths/data-analyst
@@ -23,13 +22,7 @@
 /danger_editor
 /danger-editor
 
-/georgia-tech
-/georgia-tech/faq
 /georgia-tech/welcome
-/georgiatech
-/GeorgiaTech
-/georgiatech/
-/georgiatech/faq
 /georgiatech/welcome
 # TODO (Angel): Final decision on this one
 #/grader<:.*>,GAE?,


### PR DESCRIPTION
Georgia Tech routes other than welcome should point to endor:
```
/georgia-tech       # canonical
/georgiatech
/GeorgiaTech
/georgiatech/

/georgia-tech/faq   # canonical
/georgiatech/faq
```