### PR TITLE
Updated mesos-slaves.tf to enable connection draining in ELB

### DIFF
--- a/terraform/aws/mesos-slaves.tf
+++ b/terraform/aws/mesos-slaves.tf
@@ -62,6 +62,8 @@ resource "aws_elb" "app" {
 
   instances = ["${aws_instance.mesos-slave.*.id}"]
   cross_zone_load_balancing = true
+  connection_draining = true
+  connection_draining_timeout = 300
 }
 
 resource "aws_proxy_protocol_policy" "http" {


### PR DESCRIPTION
NOTE: These settings have already been enabled in AWS via web console.
These are set to the default of 300s to match the current conf in the ELB
so that there is no detected change in Terraform currently. We can tune
later.