### PR TITLE
fix: configure proxy protocol for ELB/haproxy

### DIFF
--- a/roles/haproxy/files/haproxy.tmpl
+++ b/roles/haproxy/files/haproxy.tmpl
@@ -37,9 +37,7 @@ frontend www-http
     redirect scheme https if !{ ssl_fc }
 
 frontend www-https
-    bind *:443 ssl crt {{ env "SSL_CERT" }} ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK no-sslv3
-
-    tcp-request connection expect-proxy layer4
+    bind *:443 accept-proxy ssl crt {{ env "SSL_CERT" }} ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK no-sslv3
 
     option forwardfor
     option http-server-close
@@ -49,12 +47,13 @@ frontend www-https
     unique-id-format %{+X}o\ %ci:%cp_%fi:%fp_%Ts_%rt:%pid
     unique-id-header X-Unique-ID
 
-    # route through logger
-    no log
-    default_backend logger
-
-frontend logger
-    bind localhost:55555 accept-proxy
+# TAG: UNCOMMENT TO TURN ON FULL LOGGING
+#    # route through logger
+#    no log
+#    default_backend logger
+#
+#frontend logger
+#    bind localhost:55555 accept-proxy
 
     # %pid: process ID of HAProxy
     # %Ts.%ms: unix timestamp + milliseconds
@@ -87,11 +86,12 @@ frontend logger
     log-format [%pid]\ [%Ts.%ms]\ %ac/%fc/%bc/%bq/%sc/%sq/%rc\ %Tq/%Tw/%Tc/%Tr/%Tt\ %tsc\ %ci:%cp\ %si:%sp\ %ft\ %sslc\ %sslv\ %{+Q}r\ %ST\ %b:%s\ "%CC"\ "%hr"\ "%CS"\ "%hs"\ req_size=%U\ resp_size=%B
     log global
 
-    capture request header Referrer len 64
-    capture request header Content-Length len 10
-    capture request header User-Agent len 64
-    capture request header X-Haproxy-ACL len 256
-    capture request header X-Unique-ID len 64
+# TAG: UNCOMMENT TO TURN ON FULL LOGGING
+#    capture request header Referrer len 64
+#    capture request header Content-Length len 10
+#    capture request header User-Agent len 64
+#    capture request header X-Haproxy-ACL len 256
+#    capture request header X-Unique-ID len 64
 
     # GAE Proxy
     acl is_www_host hdr(host) -i {{env "ENDOR_SUBDOMAIN" }}.{{env "HAPROXY_DOMAIN"}}
@@ -112,8 +112,9 @@ frontend logger
     use_backend {{.Name}}_backend if host_{{.Name}}
     {{end}}{{end}}{{end}}
 
-backend logger
-    server localhost localhost:55555 send-proxy
+# TAG: UNCOMMENT TO TURN ON FULL LOGGING
+#backend logger
+#    server localhost localhost:55555 send-proxy
 
 # ProxyPass / ReverseProxyPass to GAE
 backend gae_backend

--- a/roles/haproxy/files/haproxy.tmpl
+++ b/roles/haproxy/files/haproxy.tmpl
@@ -39,7 +39,23 @@ frontend www-http
 frontend www-https
     bind *:443 ssl crt {{ env "SSL_CERT" }} ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK no-sslv3
 
-    # todo: route logs through a logging front/backend to capture all headers and cookies
+    tcp-request connection expect-proxy layer4
+
+    option forwardfor
+    option http-server-close
+    reqadd X-Forwarded-Proto:\ https
+
+    # X-Unique-ID header in requests
+    unique-id-format %{+X}o\ %ci:%cp_%fi:%fp_%Ts_%rt:%pid
+    unique-id-header X-Unique-ID
+
+    # route through logger
+    no log
+    default_backend logger
+
+frontend logger
+    bind localhost:55555 accept-proxy
+
     # %pid: process ID of HAProxy
     # %Ts.%ms: unix timestamp + milliseconds
     # %ac: total number of concurrent connections
@@ -56,7 +72,6 @@ frontend www-https
     # %Tt: total session duration time, between the moment the proxy accepted it and the moment both ends were closed.
     # %tsc: termination state (see 8.5. Session state at disconnection)
     # %ci:%cp: client IP and Port
-    # %fi:%fp: frontend IP and Port
     # %si:%sp: server IP and Port
     # %ft: transport type of the frontend (with a ~ suffix for SSL)
     # %sslc %sslv: SSL cipher and version
@@ -69,17 +84,14 @@ frontend www-https
     # %hs: captured response headers
     # %U: bytes read from the client (request size)
     # %B: bytes read from server to client (response size)
-    log-format [%pid]\ [%Ts.%ms]\ %ac/%fc/%bc/%bq/%sc/%sq/%rc\ %Tq/%Tw/%Tc/%Tr/%Tt\ %tsc\ %ci:%cp\ %fi:%fp\ %si:%sp\ %ft\ %sslc\ %sslv\ %{+Q}r\ %ST\ %b:%s\ "%CC"\ "%hr"\ "%CS"\ "%hs"\ req_size=%U\ resp_size=%B
+    log-format [%pid]\ [%Ts.%ms]\ %ac/%fc/%bc/%bq/%sc/%sq/%rc\ %Tq/%Tw/%Tc/%Tr/%Tt\ %tsc\ %ci:%cp\ %si:%sp\ %ft\ %sslc\ %sslv\ %{+Q}r\ %ST\ %b:%s\ "%CC"\ "%hr"\ "%CS"\ "%hs"\ req_size=%U\ resp_size=%B
     log global
 
-    option forwardfor
-    option http-server-close
-    reqadd X-Forwarded-Proto:\ https
-
-    # X-Unique-ID header in requests
-    unique-id-format %{+X}o\ %ci:%cp_%fi:%fp_%Ts_%rt:%pid
-    unique-id-header X-Unique-ID
-
+    capture request header Referrer len 64
+    capture request header Content-Length len 10
+    capture request header User-Agent len 64
+    capture request header X-Haproxy-ACL len 256
+    capture request header X-Unique-ID len 64
 
     # GAE Proxy
     acl is_www_host hdr(host) -i {{env "ENDOR_SUBDOMAIN" }}.{{env "HAPROXY_DOMAIN"}}
@@ -100,6 +112,8 @@ frontend www-https
     use_backend {{.Name}}_backend if host_{{.Name}}
     {{end}}{{end}}{{end}}
 
+backend logger
+    server localhost localhost:55555 send-proxy
 
 # ProxyPass / ReverseProxyPass to GAE
 backend gae_backend

--- a/terraform/aws/mesos-slaves.tf
+++ b/terraform/aws/mesos-slaves.tf
@@ -68,5 +68,5 @@ resource "aws_elb" "app" {
 
 resource "aws_proxy_protocol_policy" "http" {
   load_balancer = "${aws_elb.app.name}"
-  instance_ports = ["80"]
+  instance_ports = ["80", "443"]
 }


### PR DESCRIPTION
fix: haproxy wasn't observing the proxy-protocol and the ELB wasn't
configured for proxy-protocol on port 443

add: logging backend/frontend so detailed http header info can be logged
with each request, like X-Unique-ID