### PR TITLE
Update endor-proxy-prefix-routes.lst

### DIFF
--- a/roles/haproxy/files/endor-proxy-prefix-routes.lst
+++ b/roles/haproxy/files/endor-proxy-prefix-routes.lst
@@ -14,4 +14,4 @@
 
 # safe CMS route prefixes
 /nanodegrees
-/catalog/
+/catalog


### PR DESCRIPTION
When people click the `all` button in the catalog, they're navigating to `/catalog` and not getting redirected to `/courses/all`. The 404 appears to be coming from GAE.

Relevant ticket: https://udacity.atlassian.net/browse/EN-304

@allanbreyes @perangel 