### PR TITLE
Revert changes for trailing slash. Use path_beg for endor routes

### DIFF
--- a/roles/haproxy/files/haproxy.tmpl
+++ b/roles/haproxy/files/haproxy.tmpl
@@ -52,15 +52,9 @@ frontend www-https
     compression algo gzip
     compression type text/html text/plain text/javascript application/javascript application/xml text/css application/json application/x-javascript image/svg+xml
 
-    # Remove trailing slashes
-    acl is_www_host hdr(host) -i {{env "ENDOR_SUBDOMAIN" }}.{{env "HAPROXY_DOMAIN"}}
-    acl has_trailing_slash path_end /
-    acl is_root path /
-    http-request set-path %[path,regsub(/$,)] if has_trailing_slash is_www_host !is_root
-
     # GAE Proxy
     acl is_gae_path path_beg -i -f {{env "GAE_ROUTES_FILE"}}
-    acl is_endor_path path -i -f {{env "ENDOR_ROUTES_FILE"}}
+    acl is_endor_path path_beg -i -f {{env "ENDOR_ROUTES_FILE"}}
     acl is_endor_path path_beg -i -f {{env "ENDOR_PREFIX_ROUTES_FILE"}}
     use_backend gae_backend if is_www_host is_gae_path !is_endor_path
 

--- a/roles/haproxy/files/haproxy.tmpl
+++ b/roles/haproxy/files/haproxy.tmpl
@@ -53,6 +53,7 @@ frontend www-https
     compression type text/html text/plain text/javascript application/javascript application/xml text/css application/json application/x-javascript image/svg+xml
 
     # GAE Proxy
+    acl is_www_host hdr(host) -i {{env "ENDOR_SUBDOMAIN" }}.{{env "HAPROXY_DOMAIN"}}
     acl is_gae_path path_beg -i -f {{env "GAE_ROUTES_FILE"}}
     acl is_endor_path path_beg -i -f {{env "ENDOR_ROUTES_FILE"}}
     acl is_endor_path path_beg -i -f {{env "ENDOR_PREFIX_ROUTES_FILE"}}


### PR DESCRIPTION
These changes have caused us some issues with Video uploads, GT Wiki, and WSU OAuth.

We should not be doing this at the proxy and simply handling any slash/no-slash URLs at the service tier.

Making a pull request to get confirmation from all affected parties before rolling this out.

@AndyIsaacson 
@pmbauer 
@allanbreyes 
@cdb 
@davidjoynerudacity 
@tfdavids 
@praveen-udacity 