### PR TITLE
[NI-701] Add X-Berlioz-Country response header in haproxy

### DIFF
--- a/roles/haproxy/files/haproxy.tmpl
+++ b/roles/haproxy/files/haproxy.tmpl
@@ -133,7 +133,8 @@ backend logger
 {{range $tag, $services := services | byTag}}{{ if eq $tag "public" }}{{range $services}}
 backend {{.Name}}_backend
 {{range service .Name}}
-   server {{.Node}} {{.Address}}:{{.Port}}{{end}}
+    http-response add-header X-Berlioz-Country %[req.hdr(X-Berlioz-Country)]
+    server {{.Node}} {{.Address}}:{{.Port}}{{end}}
 {{end}}{{end}}{{end}}
 
 # Websocket service backends


### PR DESCRIPTION
This adds the X-Berlioz-Country header to all public service responses

https://udacity.atlassian.net/browse/NI-701